### PR TITLE
Preview deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ bag_manifest_compare.py
 
 delete_new_temp.py
 * bag_path (required): path to the bag (folder that ends in "_bag")
+* script_mode (required): preview (print what will delete) or delete (actually delete)
 
 undo_all_bags.py
 * bag_directory (required): path to directory that contains the bags. Bag folder names should end with "_bag".
@@ -56,6 +57,9 @@ This script finds temporary files that are not in the manifest, deletes them, an
 It does not delete temporary files that are in the manifest or non-temporary file that are not in the manifest.
 It does not try to validate if some files are missing from the manifest and not deleted, 
 but instead prints those files to review if they should be considered temporary or if the bag needs to be updated.
+
+The script can also be run in preview mode, in which case it prints files to be deleted but deletes nothing.
+This allows the archivist to check the script is deleting the correct files before doing the deletion.
 
 It was developed for fixing errors when checking bags that have been in storage for some time.
 We've found that some temporary files, especially .DS_Store and Thumbs.db, are generated on the Digital Production Hub

--- a/delete_new_temp.py
+++ b/delete_new_temp.py
@@ -66,6 +66,19 @@ def find_extra_files(bag):
     return extras
 
 
+def reminder(mode):
+    """Prints a reminder of what the selected script mode does
+    Parameter: mode (string) - preview or delete, determines if the files should just be printed or actually deleted
+    Returns: None"""
+    if mode == 'delete':
+        print('\nRunning in script_mode "delete", which will delete temp files and validate the bag.')
+    elif mode == 'preview':
+        print('\nRunning in script_mode "preview", which will print files that would be deleted but changes nothing.')
+    else:
+        print(f'\nscript_mode {mode} is not "delete" or "preview".')
+        sys.exit()
+
+
 def validate_bag(bag):
     """Validates a bag that had all extra files deleted and prints the result
     Parameter: bag (string) - path to bag
@@ -84,6 +97,9 @@ if __name__ == '__main__':
     # Get bag_path from script argument.
     bag_path = sys.argv[1]
     script_mode = sys.argv[2]
+
+    # Print reminder of script mode functionality.
+    reminder(script_mode)
 
     # Find any files that are in the bag data folder but not in the manifest (extra files).
     extra_files = find_extra_files(bag_path)

--- a/delete_new_temp.py
+++ b/delete_new_temp.py
@@ -116,4 +116,8 @@ if __name__ == '__main__':
             print("\nAfter deleting temp files, there are still files in the data folder that are not in the manifest:")
             for path in not_deleted:
                 print(f'\t* {path}')
+    elif script_mode == 'preview':
+        print("\nPreview of files to delete is complete.")
+        print("Files that would have been deleted are listed above.")
+        print(f"There are {len(not_deleted)} files that are not in the manifest and are not temp.")
 

--- a/delete_new_temp.py
+++ b/delete_new_temp.py
@@ -15,10 +15,13 @@ import re
 import sys
 
 
-def delete_temp(bag, extra_list):
+def delete_temp(bag, extra_list, mode):
     """Delete any temp files from the bag and return a list of the ones that were not deleted,
     using the same criteria as the general aip script
-    Parameter: extra_list (list) - list of paths for files that are not in the bag manifest
+    Parameters:
+        bag (string) - path to bag, needed to make full path for file
+        extra_list (list) - list of paths for files that are not in the bag manifest
+        mode (string) - preview or delete, determines if the files should just be printed or actually deleted
     Returns: not_temp (list) - list of paths for files that were not temp and therefore not deleted
     """
     not_temp = []
@@ -26,8 +29,9 @@ def delete_temp(bag, extra_list):
     for file_path in extra_list:
         file_name = file_path.split('/')[-1]
         if file_name in delete_list or file_name.endswith('.tmp') or file_name.startswith('.'):
-            print(f'Deleting {bag}/{file_path}')
-            os.remove(f'{bag}/{file_path}')
+            print(f'Delete {bag}/{file_path}')
+            if mode == 'delete':
+                os.remove(f'{bag}/{file_path}')
         else:
             not_temp.append(file_path)
     return not_temp
@@ -85,14 +89,15 @@ if __name__ == '__main__':
     extra_files = find_extra_files(bag_path)
 
     # Delete any extra files that are temp files and print the path for any other files.
-    not_deleted = delete_temp(bag_path, extra_files)
+    not_deleted = delete_temp(bag_path, extra_files, script_mode)
 
-    # If all extra files were deleted, validate the bag and print the results.
+    # If the script is in delete mode and all extra files were deleted, validate the bag and print the results.
     # Otherwise, print the files that were not deleted.
-    if len(not_deleted) == 0:
-        validate_bag(bag_path)
-    else:
-        print("\nAfter deleting temp files, there are still files in the data folder that are not in the manifest:")
-        for path in not_deleted:
-            print(f'\t* {path}')
+    if script_mode == 'delete':
+        if len(not_deleted) == 0:
+            validate_bag(bag_path)
+        else:
+            print("\nAfter deleting temp files, there are still files in the data folder that are not in the manifest:")
+            for path in not_deleted:
+                print(f'\t* {path}')
 

--- a/delete_new_temp.py
+++ b/delete_new_temp.py
@@ -38,7 +38,7 @@ def find_extra_files(bag):
     Returns: extras (list) - list of the paths for every file in data but not the manifest
     """
     # List of file paths in the data folder, saved as a dataframe to compare to manifest.
-    # To match the manifest, it needs to start at data and use forward slashes.
+    # To match the manifest, the path needs to start at data and use forward slashes.
     data_paths = []
     for root, dirs, files in os.walk(os.path.join(bag, 'data')):
         for file in files:
@@ -48,8 +48,11 @@ def find_extra_files(bag):
     data_df = pd.DataFrame(data_paths, columns=['Data_Paths'])
 
     # Read the bag manifest into a dataframe.
-    manifest_df = pd.read_csv(os.path.join(bag, 'manifest-md5.txt'), sep='  ', engine='python',
+    # data (start of the path) has to be used as part of the separator because paths may also include a double space,
+    # and needs to be added back so future paths are correct.
+    manifest_df = pd.read_csv(os.path.join(bag, 'manifest-md5.txt'), sep='  data', engine='python',
                               names=['MD5', 'Manifest_Paths'])
+    manifest_df['Manifest_Paths'] = 'data' + manifest_df['Manifest_Paths']
 
     # Compare the data path list and the bag manifest, and return those only in the data path list.
     compare_df = data_df.merge(manifest_df, left_on='Data_Paths', right_on='Manifest_Paths', how='left')

--- a/delete_new_temp.py
+++ b/delete_new_temp.py
@@ -71,7 +71,7 @@ def reminder(mode):
     Parameter: mode (string) - preview or delete, determines if the files should just be printed or actually deleted
     Returns: None"""
     if mode == 'delete':
-        print('\nRunning in script_mode "delete", which will delete temp files and validate the bag.')
+        print('\nRunning in script_mode "delete", which will delete extra temp files and validate the bag.')
     elif mode == 'preview':
         print('\nRunning in script_mode "preview", which will print files that would be deleted but changes nothing.')
     else:

--- a/delete_new_temp.py
+++ b/delete_new_temp.py
@@ -2,6 +2,7 @@
 
 Parameter:
     bag_path (required): path to the bag (folder that ends in "_bag")
+    script_mode (required): preview (print what will delete) or delete (actually delete)
 
 Returns:
     Prints any files that are not in the manifest but did not quality as temporary files
@@ -78,6 +79,7 @@ def validate_bag(bag):
 if __name__ == '__main__':
     # Get bag_path from script argument.
     bag_path = sys.argv[1]
+    script_mode = sys.argv[2]
 
     # Find any files that are in the bag data folder but not in the manifest (extra files).
     extra_files = find_extra_files(bag_path)

--- a/delete_new_temp.py
+++ b/delete_new_temp.py
@@ -48,7 +48,7 @@ def find_extra_files(bag):
     data_df = pd.DataFrame(data_paths, columns=['Data_Paths'])
 
     # Read the bag manifest into a dataframe.
-    manifest_df = pd.read_csv(os.path.join(bag, 'manifest-md5.txt'), sep='  data', engine='python',
+    manifest_df = pd.read_csv(os.path.join(bag, 'manifest-md5.txt'), sep='  ', engine='python',
                               names=['MD5', 'Manifest_Paths'])
 
     # Compare the data path list and the bag manifest, and return those only in the data path list.

--- a/tests/test_delete_new_temp.py
+++ b/tests/test_delete_new_temp.py
@@ -61,9 +61,9 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for extra_temp, directory")
 
         # Test for the printed information.
-        expected = (f"Deleting {new_bag_path}/data/.Document.txt\n"
-                    f"Deleting {new_bag_path}/data/Document.tmp\n"
-                    f"Deleting {new_bag_path}/data/Folder/Thumbs.db\n"
+        expected = (f"Delete {new_bag_path}/data/.Document.txt\n"
+                    f"Delete {new_bag_path}/data/Document.tmp\n"
+                    f"Delete {new_bag_path}/data/Folder/Thumbs.db\n"
                     f"\nBag is valid\n")
         self.assertEqual(expected, printed.stdout, "Problem with test for extra_temp, printed")
 
@@ -84,8 +84,8 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for extra_temp_with_spaces, directory")
 
         # Test for the printed information.
-        expected = (f"Deleting {new_bag_path}/data/Document  Temp.tmp\n"
-                    f"Deleting {new_bag_path}/data/Folder  Title/Document.tmp\n"
+        expected = (f"Delete {new_bag_path}/data/Document  Temp.tmp\n"
+                    f"Delete {new_bag_path}/data/Folder  Title/Document.tmp\n"
                     f"\nBag is valid\n")
         self.assertEqual(expected, printed.stdout, "Problem with test for extra_temp_with_spaces, printed")
 
@@ -127,7 +127,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for temp_not_all_extra, directory")
 
         # Test for the printed information.
-        expected = (f"Deleting {new_bag_path}/data/Folder/.Document.txt\n"
+        expected = (f"Delete {new_bag_path}/data/Folder/.Document.txt\n"
                     f"\nBag is valid\n")
         self.assertEqual(expected, printed.stdout, "Problem with test for temp_not_all_extra, printed")
 

--- a/tests/test_delete_new_temp.py
+++ b/tests/test_delete_new_temp.py
@@ -33,7 +33,7 @@ class MyTestCase(unittest.TestCase):
         bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'extra_not_temp_bag')
         new_bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'test_extra_not_temp_bag')
         shutil.copytree(bag_path, new_bag_path)
-        printed = subprocess.run(f'python {script_path} {new_bag_path}', capture_output=True, text=True, shell=True)
+        printed = subprocess.run(f'python {script_path} {new_bag_path} delete', capture_output=True, text=True, shell=True)
 
         # Test for the directory contents.
         result = make_directory_list(new_bag_path)
@@ -53,7 +53,7 @@ class MyTestCase(unittest.TestCase):
         bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'extra_temp_bag')
         new_bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'test_extra_temp_bag')
         shutil.copytree(bag_path, new_bag_path)
-        printed = subprocess.run(f'python {script_path} {new_bag_path}', capture_output=True, text=True, shell=True)
+        printed = subprocess.run(f'python {script_path} {new_bag_path} delete', capture_output=True, text=True, shell=True)
 
         # Test for the directory contents.
         result = make_directory_list(new_bag_path)
@@ -76,7 +76,7 @@ class MyTestCase(unittest.TestCase):
         bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'extra_temp_with_spaces_bag')
         new_bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'test_extra_temp_with_spaces_bag')
         shutil.copytree(bag_path, new_bag_path)
-        printed = subprocess.run(f'python {script_path} {new_bag_path}', capture_output=True, text=True, shell=True)
+        printed = subprocess.run(f'python {script_path} {new_bag_path} delete', capture_output=True, text=True, shell=True)
 
         # Test for the directory contents.
         result = make_directory_list(new_bag_path)
@@ -96,7 +96,7 @@ class MyTestCase(unittest.TestCase):
         bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'not_valid_bag')
         new_bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'test_not_valid_bag')
         shutil.copytree(bag_path, new_bag_path)
-        printed = subprocess.run(f'python {script_path} {new_bag_path}', capture_output=True, text=True, shell=True)
+        printed = subprocess.run(f'python {script_path} {new_bag_path} delete', capture_output=True, text=True, shell=True)
 
         # Test for the directory contents.
         result = make_directory_list(new_bag_path)
@@ -118,7 +118,7 @@ class MyTestCase(unittest.TestCase):
         bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'temp_not_all_extra_bag')
         new_bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'test_temp_not_all_extra_bag')
         shutil.copytree(bag_path, new_bag_path)
-        printed = subprocess.run(f'python {script_path} {new_bag_path}', capture_output=True, text=True, shell=True)
+        printed = subprocess.run(f'python {script_path} {new_bag_path} delete', capture_output=True, text=True, shell=True)
 
         # Test for the directory contents.
         result = make_directory_list(new_bag_path)

--- a/tests/test_delete_new_temp.py
+++ b/tests/test_delete_new_temp.py
@@ -26,6 +26,7 @@ class MyTestCase(unittest.TestCase):
                 shutil.rmtree(bag_path)
 
     def test_extra_not_temp(self):
+        """Test for when files were added after bagging, but they are not temp files and are not deleted"""
         # Make a copy of the test data, since the script deletes files.
         script_path = os.path.join('', '..', 'delete_new_temp.py')
         bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'extra_not_temp_bag')
@@ -44,6 +45,8 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, printed.stdout, "Problem with test for extra_not_temp, printed")
 
     def test_extra_temp(self):
+        """Test for when files were added after bagging, all are temp files that will be deleted,
+        and the bag will be valid after the deletion"""
         # Make a copy of the test data, since the script deletes files.
         script_path = os.path.join('', '..', 'delete_new_temp.py')
         bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'extra_temp_bag')
@@ -57,10 +60,14 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for extra_temp, directory")
 
         # Test for the printed information.
-        expected = "\nBag is valid\n"
+        expected = (f"Deleting {new_bag_path}/data/.Document.txt\n"
+                    f"Deleting {new_bag_path}/data/Document.tmp\n"
+                    f"Deleting {new_bag_path}/data/Folder/Thumbs.db\n"
+                    f"\nBag is valid\n")
         self.assertEqual(expected, printed.stdout, "Problem with test for extra_temp, printed")
 
     def test_not_valid(self):
+        """Test for a bag with no extra files but that is not valid from the start"""
         # Make a copy of the test data, since the script deletes files.
         script_path = os.path.join('', '..', 'delete_new_temp.py')
         bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'not_valid_bag')
@@ -81,6 +88,8 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, printed.stdout, "Problem with test for not_valid, printed")
 
     def test_temp_not_all_extra(self):
+        """Test for a bag with some temp files that are in the manifest and should not be deleted
+        and a temp file added after bagging that should be deleted, after which the bag will validate"""
         # Make a copy of the test data, since the script deletes files.
         script_path = os.path.join('', '..', 'delete_new_temp.py')
         bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'temp_not_all_extra_bag')
@@ -95,7 +104,8 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for temp_not_all_extra, directory")
 
         # Test for the printed information.
-        expected = "\nBag is valid\n"
+        expected = (f"Deleting {new_bag_path}/data/Folder/.Document.txt\n"
+                    f"\nBag is valid\n")
         self.assertEqual(expected, printed.stdout, "Problem with test for temp_not_all_extra, printed")
 
 

--- a/tests/test_delete_new_temp.py
+++ b/tests/test_delete_new_temp.py
@@ -46,6 +46,27 @@ class MyTestCase(unittest.TestCase):
                     '\t* data/Extra.txt\n\t* data/Folder/Extra2.txt\n')
         self.assertEqual(expected, printed.stdout, "Problem with test for extra_not_temp, printed")
 
+    def test_extra_not_temp_preview(self):
+        """Test for when files were added after bagging, but they are not temp files, in preview mode"""
+        # Make a copy of the test data, since the script deletes files.
+        script_path = os.path.join('', '..', 'delete_new_temp.py')
+        bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'extra_not_temp_bag')
+        new_bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'test_extra_not_temp_bag')
+        shutil.copytree(bag_path, new_bag_path)
+        printed = subprocess.run(f'python {script_path} {new_bag_path} preview', capture_output=True, text=True, shell=True)
+
+        # Test for the directory contents.
+        result = make_directory_list(new_bag_path)
+        expected = ['data\\Document.txt', 'data\\Extra.txt', 'data\\Folder\\Document.txt', 'data\\Folder\\Extra2.txt']
+        self.assertEqual(expected, result, "Problem with test for extra_not_temp_preview, directory")
+
+        # Test for the printed information.
+        expected = ('\nRunning in script_mode "preview", which will print files that would be deleted but changes nothing.\n'
+                    '\nPreview of files to delete is complete.\n'
+                    'Files that would have been deleted are listed above.\n'
+                    'There are 2 files that are not in the manifest and are not temp.\n')
+        self.assertEqual(expected, printed.stdout, "Problem with test for extra_not_temp_preview, printed")
+
     def test_extra_temp(self):
         """Test for when files were added after bagging, all are temp files that will be deleted,
         and the bag will be valid after the deletion"""
@@ -68,6 +89,32 @@ class MyTestCase(unittest.TestCase):
                     f'Delete {new_bag_path}/data/Folder/Thumbs.db\n'
                     '\nBag is valid\n')
         self.assertEqual(expected, printed.stdout, "Problem with test for extra_temp, printed")
+
+    def test_extra_temp_preview(self):
+        """Test for when files were added after bagging and the script is in preview mode,
+        so they'll be printed but not deleted"""
+        # Make a copy of the test data, since the script deletes files.
+        script_path = os.path.join('', '..', 'delete_new_temp.py')
+        bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'extra_temp_bag')
+        new_bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'test_extra_temp_bag')
+        shutil.copytree(bag_path, new_bag_path)
+        printed = subprocess.run(f'python {script_path} {new_bag_path} preview', capture_output=True, text=True, shell=True)
+
+        # Test for the directory contents.
+        result = make_directory_list(new_bag_path)
+        expected = ['data\\.Document.txt', 'data\\Document.tmp', 'data\\Document.txt',
+                    'data\\Folder\\Document.txt', 'data\\Folder\\Thumbs.db']
+        self.assertEqual(expected, result, "Problem with test for extra_temp_preview, directory")
+
+        # Test for the printed information.
+        expected = ('\nRunning in script_mode "preview", which will print files that would be deleted but changes nothing.\n'
+                    f'Delete {new_bag_path}/data/.Document.txt\n'
+                    f'Delete {new_bag_path}/data/Document.tmp\n'
+                    f'Delete {new_bag_path}/data/Folder/Thumbs.db\n'
+                    '\nPreview of files to delete is complete.\n'
+                    'Files that would have been deleted are listed above.\n'
+                    'There are 0 files that are not in the manifest and are not temp.\n')
+        self.assertEqual(expected, printed.stdout, "Problem with test for extra_temp_preview, printed")
 
     def test_extra_temp_with_spaces(self):
         """Test for when files were added after bagging, all are temp files that will be deleted,

--- a/tests/test_delete_new_temp.py
+++ b/tests/test_delete_new_temp.py
@@ -41,8 +41,9 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for extra_not_temp, directory")
 
         # Test for the printed information.
-        expected = ("\nAfter deleting temp files, there are still files in the data folder that are not in the manifest:\n"
-                    "\t* data/Extra.txt\n\t* data/Folder/Extra2.txt\n")
+        expected = ('\nRunning in script_mode "delete", which will delete temp files and validate the bag.\n'
+                    '\nAfter deleting temp files, there are still files in the data folder that are not in the manifest:\n'
+                    '\t* data/Extra.txt\n\t* data/Folder/Extra2.txt\n')
         self.assertEqual(expected, printed.stdout, "Problem with test for extra_not_temp, printed")
 
     def test_extra_temp(self):
@@ -61,10 +62,11 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for extra_temp, directory")
 
         # Test for the printed information.
-        expected = (f"Delete {new_bag_path}/data/.Document.txt\n"
-                    f"Delete {new_bag_path}/data/Document.tmp\n"
-                    f"Delete {new_bag_path}/data/Folder/Thumbs.db\n"
-                    f"\nBag is valid\n")
+        expected = ('\nRunning in script_mode "delete", which will delete temp files and validate the bag.\n'
+                    f'Delete {new_bag_path}/data/.Document.txt\n'
+                    f'Delete {new_bag_path}/data/Document.tmp\n'
+                    f'Delete {new_bag_path}/data/Folder/Thumbs.db\n'
+                    '\nBag is valid\n')
         self.assertEqual(expected, printed.stdout, "Problem with test for extra_temp, printed")
 
     def test_extra_temp_with_spaces(self):
@@ -84,9 +86,10 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for extra_temp_with_spaces, directory")
 
         # Test for the printed information.
-        expected = (f"Delete {new_bag_path}/data/Document  Temp.tmp\n"
-                    f"Delete {new_bag_path}/data/Folder  Title/Document.tmp\n"
-                    f"\nBag is valid\n")
+        expected = ('\nRunning in script_mode "delete", which will delete temp files and validate the bag.\n'
+                    f'Delete {new_bag_path}/data/Document  Temp.tmp\n'
+                    f'Delete {new_bag_path}/data/Folder  Title/Document.tmp\n'
+                    f'\nBag is valid\n')
         self.assertEqual(expected, printed.stdout, "Problem with test for extra_temp_with_spaces, printed")
 
     def test_not_valid(self):
@@ -104,7 +107,8 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for not_valid, directory")
 
         # Test for the printed information.
-        expected = ('\nBag is not valid\nBag validation failed: data\Document.txt md5 validation failed: '
+        expected = ('\nRunning in script_mode "delete", which will delete temp files and validate the bag.\n'
+                    '\nBag is not valid\nBag validation failed: data\Document.txt md5 validation failed: '
                     'expected="4xx51d0000698119300eb0c54dbaxx89" found="4bb51d0461698119344eb0c54dbabb89"; '
                     'data\Folder\Document.txt md5 validation failed: expected="4xx51d0000698119300eb0c54dbaxx89" '
                     'found="4bb51d0461698119344eb0c54dbabb89"\n')
@@ -127,8 +131,9 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for temp_not_all_extra, directory")
 
         # Test for the printed information.
-        expected = (f"Delete {new_bag_path}/data/Folder/.Document.txt\n"
-                    f"\nBag is valid\n")
+        expected = ('\nRunning in script_mode "delete", which will delete temp files and validate the bag.\n'
+                    f'Delete {new_bag_path}/data/Folder/.Document.txt\n'
+                    f'\nBag is valid\n')
         self.assertEqual(expected, printed.stdout, "Problem with test for temp_not_all_extra, printed")
 
 

--- a/tests/test_delete_new_temp.py
+++ b/tests/test_delete_new_temp.py
@@ -41,7 +41,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for extra_not_temp, directory")
 
         # Test for the printed information.
-        expected = ('\nRunning in script_mode "delete", which will delete temp files and validate the bag.\n'
+        expected = ('\nRunning in script_mode "delete", which will delete extra temp files and validate the bag.\n'
                     '\nAfter deleting temp files, there are still files in the data folder that are not in the manifest:\n'
                     '\t* data/Extra.txt\n\t* data/Folder/Extra2.txt\n')
         self.assertEqual(expected, printed.stdout, "Problem with test for extra_not_temp, printed")
@@ -83,7 +83,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for extra_temp, directory")
 
         # Test for the printed information.
-        expected = ('\nRunning in script_mode "delete", which will delete temp files and validate the bag.\n'
+        expected = ('\nRunning in script_mode "delete", which will delete extra temp files and validate the bag.\n'
                     f'Delete {new_bag_path}/data/.Document.txt\n'
                     f'Delete {new_bag_path}/data/Document.tmp\n'
                     f'Delete {new_bag_path}/data/Folder/Thumbs.db\n'
@@ -133,7 +133,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for extra_temp_with_spaces, directory")
 
         # Test for the printed information.
-        expected = ('\nRunning in script_mode "delete", which will delete temp files and validate the bag.\n'
+        expected = ('\nRunning in script_mode "delete", which will delete extra temp files and validate the bag.\n'
                     f'Delete {new_bag_path}/data/Document  Temp.tmp\n'
                     f'Delete {new_bag_path}/data/Folder  Title/Document.tmp\n'
                     f'\nBag is valid\n')
@@ -154,7 +154,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for not_valid, directory")
 
         # Test for the printed information.
-        expected = ('\nRunning in script_mode "delete", which will delete temp files and validate the bag.\n'
+        expected = ('\nRunning in script_mode "delete", which will delete extra temp files and validate the bag.\n'
                     '\nBag is not valid\nBag validation failed: data\Document.txt md5 validation failed: '
                     'expected="4xx51d0000698119300eb0c54dbaxx89" found="4bb51d0461698119344eb0c54dbabb89"; '
                     'data\Folder\Document.txt md5 validation failed: expected="4xx51d0000698119300eb0c54dbaxx89" '
@@ -178,7 +178,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for temp_not_all_extra, directory")
 
         # Test for the printed information.
-        expected = ('\nRunning in script_mode "delete", which will delete temp files and validate the bag.\n'
+        expected = ('\nRunning in script_mode "delete", which will delete extra temp files and validate the bag.\n'
                     f'Delete {new_bag_path}/data/Folder/.Document.txt\n'
                     f'\nBag is valid\n')
         self.assertEqual(expected, printed.stdout, "Problem with test for temp_not_all_extra, printed")

--- a/tests/test_delete_new_temp.py
+++ b/tests/test_delete_new_temp.py
@@ -19,7 +19,8 @@ class MyTestCase(unittest.TestCase):
 
     def tearDown(self):
         """Delete copies of test data, if made"""
-        bags = ['test_extra_not_temp_bag', 'test_extra_temp_bag', 'test_not_valid_bag', 'test_temp_not_all_extra_bag']
+        bags = ['test_extra_not_temp_bag', 'test_extra_temp_bag', 'test_extra_temp_with_spaces_bag',
+                'test_not_valid_bag', 'test_temp_not_all_extra_bag']
         for bag in bags:
             bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', bag)
             if os.path.exists(bag_path):
@@ -65,6 +66,28 @@ class MyTestCase(unittest.TestCase):
                     f"Deleting {new_bag_path}/data/Folder/Thumbs.db\n"
                     f"\nBag is valid\n")
         self.assertEqual(expected, printed.stdout, "Problem with test for extra_temp, printed")
+
+    def test_extra_temp_with_spaces(self):
+        """Test for when files were added after bagging, all are temp files that will be deleted,
+        there are folders and files with double spaces (impacts manifest parsing),
+        and the bag will be valid after the deletion"""
+        # Make a copy of the test data, since the script deletes files.
+        script_path = os.path.join('', '..', 'delete_new_temp.py')
+        bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'extra_temp_with_spaces_bag')
+        new_bag_path = os.path.join(os.getcwd(), 'test_delete_new_temp', 'test_extra_temp_with_spaces_bag')
+        shutil.copytree(bag_path, new_bag_path)
+        printed = subprocess.run(f'python {script_path} {new_bag_path}', capture_output=True, text=True, shell=True)
+
+        # Test for the directory contents.
+        result = make_directory_list(new_bag_path)
+        expected = ['data\\Document.txt', 'data\\Folder  Title\\New  Document.txt']
+        self.assertEqual(expected, result, "Problem with test for extra_temp_with_spaces, directory")
+
+        # Test for the printed information.
+        expected = (f"Deleting {new_bag_path}/data/Document  Temp.tmp\n"
+                    f"Deleting {new_bag_path}/data/Folder  Title/Document.tmp\n"
+                    f"\nBag is valid\n")
+        self.assertEqual(expected, printed.stdout, "Problem with test for extra_temp_with_spaces, printed")
 
     def test_not_valid(self):
         """Test for a bag with no extra files but that is not valid from the start"""

--- a/tests/test_delete_new_temp/extra_temp_bag/tagmanifest-md5.txt
+++ b/tests/test_delete_new_temp/extra_temp_bag/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-cc239bc9b014e758314babcaca4843a7 bag-info.txt
-9e5ad981e0d29adc278f6a294b8c2aca bagit.txt
-aa6c9e8d2dc2ed74a0ac9b3845dc84db manifest-md5.txt
+b30e00fe1b66c0e7590cb4dc772f0a3a bag-info.txt
+defc71b28593bb73c7c94a8332f85da8 bagit.txt
+806df6f87f4dcaf0446f19dfd75d5392 manifest-md5.txt

--- a/tests/test_delete_new_temp/extra_temp_with_spaces_bag/bag-info.txt
+++ b/tests/test_delete_new_temp/extra_temp_with_spaces_bag/bag-info.txt
@@ -1,0 +1,3 @@
+Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
+Bagging-Date: 2025-09-22
+Payload-Oxum: 64.2

--- a/tests/test_delete_new_temp/extra_temp_with_spaces_bag/bagit.txt
+++ b/tests/test_delete_new_temp/extra_temp_with_spaces_bag/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/tests/test_delete_new_temp/extra_temp_with_spaces_bag/data/Document  Temp.tmp
+++ b/tests/test_delete_new_temp/extra_temp_with_spaces_bag/data/Document  Temp.tmp
@@ -1,0 +1,1 @@
+Placeholder for expected content

--- a/tests/test_delete_new_temp/extra_temp_with_spaces_bag/data/Document.txt
+++ b/tests/test_delete_new_temp/extra_temp_with_spaces_bag/data/Document.txt
@@ -1,0 +1,1 @@
+Placeholder for expected content

--- a/tests/test_delete_new_temp/extra_temp_with_spaces_bag/data/Folder  Title/Document.tmp
+++ b/tests/test_delete_new_temp/extra_temp_with_spaces_bag/data/Folder  Title/Document.tmp
@@ -1,0 +1,2 @@
+Placeholder for a file added after bagging.
+It is a temp file based on the extension and will be deleted.

--- a/tests/test_delete_new_temp/extra_temp_with_spaces_bag/data/Folder  Title/New  Document.txt
+++ b/tests/test_delete_new_temp/extra_temp_with_spaces_bag/data/Folder  Title/New  Document.txt
@@ -1,0 +1,1 @@
+Placeholder for expected content

--- a/tests/test_delete_new_temp/extra_temp_with_spaces_bag/manifest-md5.txt
+++ b/tests/test_delete_new_temp/extra_temp_with_spaces_bag/manifest-md5.txt
@@ -1,0 +1,2 @@
+4bb51d0461698119344eb0c54dbabb89  data/Document.txt
+4bb51d0461698119344eb0c54dbabb89  data/Folder  Title/New  Document.txt

--- a/tests/test_delete_new_temp/extra_temp_with_spaces_bag/tagmanifest-md5.txt
+++ b/tests/test_delete_new_temp/extra_temp_with_spaces_bag/tagmanifest-md5.txt
@@ -1,0 +1,3 @@
+cb357ef812fffaa3116c98cac60090c6 bag-info.txt
+9e5ad981e0d29adc278f6a294b8c2aca bagit.txt
+d05379800c640a8ba435d949a7f468fb manifest-md5.txt

--- a/tests/test_delete_new_temp/not_valid_bag/tagmanifest-md5.txt
+++ b/tests/test_delete_new_temp/not_valid_bag/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-cc239bc9b014e758314babcaca4843a7 bag-info.txt
-9e5ad981e0d29adc278f6a294b8c2aca bagit.txt
-00c4cf5f178754de586b2d4b58bc9356 manifest-md5.txt
+b30e00fe1b66c0e7590cb4dc772f0a3a bag-info.txt
+defc71b28593bb73c7c94a8332f85da8 bagit.txt
+04f5d70b928c1c3b0f560425eb9d1142 manifest-md5.txt

--- a/tests/test_delete_new_temp/temp_not_all_extra_bag/tagmanifest-md5.txt
+++ b/tests/test_delete_new_temp/temp_not_all_extra_bag/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-b196772c32092cd14c0746bdd2e3c452 bag-info.txt
-9e5ad981e0d29adc278f6a294b8c2aca bagit.txt
-eb8ce85684bc4fddfdb8e404e5031ffc manifest-md5.txt
+ca453a469122a943d76949dfcb4e8ec7 bag-info.txt
+defc71b28593bb73c7c94a8332f85da8 bagit.txt
+f7f463fe1903b54ebb478c164c342f7e manifest-md5.txt


### PR DESCRIPTION
For delete_new_temp.py, add the option to preview what will deleted prior to deleting everything. Especially while we're getting confident that the script works on real data, it is helpful to know it is performing as expected for a given bag prior to allowing the bag to be altered by deleting files.

Also fixed a bug with how the separator had been updated, to work on manifests that have double spaces not just between the MD5 and path but also within the bag. The sep is "  data" but data has to be put back on the path to match the directory.