### PR TITLE
Delete thumbdb #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ bag_manifest_compare_files.py
 bag_manifest_compare_fixity.py
 * bag_path (required): path to the bag (folder that ends in "_bag")
 
+delete_thumbs_db.py
+* bag_path (required): path to the bag (folder that ends in "_bag")
+ 
 delete_new_temp.py
 * bag_path (required): path to the bag (folder that ends in "_bag")
 * script_mode (required): preview (print what will delete) or delete (actually delete)
@@ -87,6 +90,14 @@ Standardized language for the preservation log:
 
 Updated bag for accession 20##.##.ER to remove temp files generated after bagging with delete_new_temp.py. 1 Thumbs.db was deleted. The bag is valid.
 Updated bag for accession 20##.##.ER to remove temp files generated after bagging with delete_new_temp.py. 1 Thumbs.db was deleted. The bag is not valid. [insert error message]
+
+### delete_thumbs_db.py
+
+This script deletes Thumbs.db anywhere in the bag, regardless of if there were in the manifest or not,
+updates the bag, and validates the bag.
+
+It should only be used after delete_new_temp.py or one of the bag manifest compare scripts shows that
+Thumbs.db are the only reason the bag is not validating, because it updates the bag.
 
 ### undo_all_bags.py and undo_one_bag.py
 

--- a/delete_thumbs_db.py
+++ b/delete_thumbs_db.py
@@ -16,12 +16,23 @@ import sys
 from delete_new_temp import validate_bag
 
 
+def delete_thumbs(bag):
+    """Delete any Thumbs.db files in the bag
+    Parameter: bag (string) - path to bag
+    Returns: None"""
+    for root, dirs, files in os.walk(bag):
+        for file in files:
+            if file == 'Thumbs.db':
+                os.remove(os.path.join(root, file))
+
+
 if __name__ == '__main__':
 
     # Get bag_path from script argument.
     bag_path = sys.argv[1]
 
     # Delete any Thumbs.db in the bag's data folder.
+    delete_thumbs(bag_path)
 
     # Update the bag.
 

--- a/delete_thumbs_db.py
+++ b/delete_thumbs_db.py
@@ -26,6 +26,14 @@ def delete_thumbs(bag):
                 os.remove(os.path.join(root, file))
 
 
+def update_bag(bag):
+    """Update the bag so any Thumbs.db that were part of the manifest are removed
+    Parameter: bag (string) - path to bag
+    Returns: None"""
+    bag_inst = bagit.Bag(bag)
+    bag_inst.save(manifests=True)
+
+
 if __name__ == '__main__':
 
     # Get bag_path from script argument.
@@ -35,6 +43,7 @@ if __name__ == '__main__':
     delete_thumbs(bag_path)
 
     # Update the bag.
+    update_bag(bag_path)
 
-    # Validate the bag.
+    # Validate the bag and print the result.
     validate_bag(bag_path)

--- a/delete_thumbs_db.py
+++ b/delete_thumbs_db.py
@@ -1,0 +1,29 @@
+"""Remove any Thumbs.db in the bag, update the bag, and validate the bag
+
+Thumbs.db can auto-generate after the bag is made or change after the bag is made,
+causing bag validation errors in bags that are part of the backlog for a while.
+This script corrects it so the bag can be validated and any non-Thumbs.db errors identified.
+
+Parameter:
+    bag_path (required): path to the bag (folder that ends in "_bag")
+
+Returns:
+    Prints the validation result
+"""
+import bagit
+import os
+import sys
+from delete_new_temp import validate_bag
+
+
+if __name__ == '__main__':
+
+    # Get bag_path from script argument.
+    bag_path = sys.argv[1]
+
+    # Delete any Thumbs.db in the bag's data folder.
+
+    # Update the bag.
+
+    # Validate the bag.
+    validate_bag(bag_path)

--- a/tests/test_delete_thumbs_db.py
+++ b/tests/test_delete_thumbs_db.py
@@ -1,0 +1,56 @@
+import os
+import shutil
+import subprocess
+import unittest
+from test_delete_new_temp import make_directory_list
+
+
+class MyTestCase(unittest.TestCase):
+
+    def tearDown(self):
+        """Delete copies of test data, if made"""
+        bags = ['test_manifest_bag', 'test_not_manifest_bag']
+        for bag in bags:
+            bag_path = os.path.join(os.getcwd(), 'test_delete_thumbs_db', bag)
+            if os.path.exists(bag_path):
+                shutil.rmtree(bag_path)
+
+    def test_manifest(self):
+        """Test for when 1 Thumbs.db file is in the bag manifest"""
+        # Make variables and copy of the test data (script deletes files) and run the script.
+        script_path = os.path.join('..', 'delete_thumbs_db.py')
+        bag_path = os.path.join(os.getcwd(), 'test_delete_thumbs_db', 'manifest_bag')
+        new_bag_path = os.path.join(os.getcwd(), 'test_delete_thumbs_db', 'test_manifest_bag')
+        shutil.copytree(bag_path, new_bag_path)
+        printed = subprocess.run(f'python {script_path} {new_bag_path}', capture_output=True, text=True, shell=True)
+
+        # Test for the directory contents.
+        result = make_directory_list(new_bag_path)
+        expected = ['data\\Document.txt']
+        self.assertEqual(expected, result, "Problem with test for manifest, directory")
+
+        # Test for the printed information.
+        expected = '\nBag is valid\n'
+        self.assertEqual(expected, printed.stdout, "Problem with test for manifest, printed text")
+
+    def test_not_manifest(self):
+        """Test for when 2 Thumbs.db files are in the bag but not the manifest"""
+        # Make variables and copy of the test data (script deletes files) and run the script.
+        script_path = os.path.join('..', 'delete_thumbs_db.py')
+        bag_path = os.path.join(os.getcwd(), 'test_delete_thumbs_db', 'not_manifest_bag')
+        new_bag_path = os.path.join(os.getcwd(), 'test_delete_thumbs_db', 'test_not_manifest_bag')
+        shutil.copytree(bag_path, new_bag_path)
+        printed = subprocess.run(f'python {script_path} {new_bag_path}', capture_output=True, text=True, shell=True)
+
+        # Test for the directory contents.
+        result = make_directory_list(new_bag_path)
+        expected = ['data\\Document.txt', 'data\\Folder\\Document.txt']
+        self.assertEqual(expected, result, "Problem with test for not_manifest, directory")
+
+        # Test for the printed information.
+        expected = '\nBag is valid\n'
+        self.assertEqual(expected, printed.stdout, "Problem with test for not_manifest, printed text")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_delete_thumbs_db/manifest_bag/bag-info.txt
+++ b/tests/test_delete_thumbs_db/manifest_bag/bag-info.txt
@@ -1,0 +1,3 @@
+Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
+Bagging-Date: 2025-10-02
+Payload-Oxum: 54.2

--- a/tests/test_delete_thumbs_db/manifest_bag/bagit.txt
+++ b/tests/test_delete_thumbs_db/manifest_bag/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/tests/test_delete_thumbs_db/manifest_bag/data/Document.txt
+++ b/tests/test_delete_thumbs_db/manifest_bag/data/Document.txt
@@ -1,0 +1,1 @@
+Intended content for the bag.

--- a/tests/test_delete_thumbs_db/manifest_bag/data/Thumbs.db
+++ b/tests/test_delete_thumbs_db/manifest_bag/data/Thumbs.db
@@ -1,0 +1,1 @@
+Placeholder for Thumbs.db

--- a/tests/test_delete_thumbs_db/manifest_bag/manifest-md5.txt
+++ b/tests/test_delete_thumbs_db/manifest_bag/manifest-md5.txt
@@ -1,0 +1,2 @@
+d98653c4abcca7e5156e92db5e5bde51  data/Document.txt
+63f03de44e9e384a9913bafb6d2e0faf  data/Thumbs.db

--- a/tests/test_delete_thumbs_db/manifest_bag/tagmanifest-md5.txt
+++ b/tests/test_delete_thumbs_db/manifest_bag/tagmanifest-md5.txt
@@ -1,0 +1,3 @@
+cf10247cb4cf9b447218d87aaa6e2b1c bag-info.txt
+9e5ad981e0d29adc278f6a294b8c2aca bagit.txt
+a854c35611174e2e47ed2f6ebe49583c manifest-md5.txt

--- a/tests/test_delete_thumbs_db/not_manifest_bag/bag-info.txt
+++ b/tests/test_delete_thumbs_db/not_manifest_bag/bag-info.txt
@@ -1,0 +1,3 @@
+Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
+Bagging-Date: 2025-10-02
+Payload-Oxum: 58.2

--- a/tests/test_delete_thumbs_db/not_manifest_bag/bagit.txt
+++ b/tests/test_delete_thumbs_db/not_manifest_bag/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/tests/test_delete_thumbs_db/not_manifest_bag/data/Document.txt
+++ b/tests/test_delete_thumbs_db/not_manifest_bag/data/Document.txt
@@ -1,0 +1,1 @@
+Intended content for the bag.

--- a/tests/test_delete_thumbs_db/not_manifest_bag/data/Folder/Document.txt
+++ b/tests/test_delete_thumbs_db/not_manifest_bag/data/Folder/Document.txt
@@ -1,0 +1,1 @@
+Intended content for the bag.

--- a/tests/test_delete_thumbs_db/not_manifest_bag/data/Folder/Thumbs.db
+++ b/tests/test_delete_thumbs_db/not_manifest_bag/data/Folder/Thumbs.db
@@ -1,0 +1,1 @@
+Placeholder for Thumbs.db

--- a/tests/test_delete_thumbs_db/not_manifest_bag/data/Thumbs.db
+++ b/tests/test_delete_thumbs_db/not_manifest_bag/data/Thumbs.db
@@ -1,0 +1,1 @@
+Placeholder for Thumbs.db

--- a/tests/test_delete_thumbs_db/not_manifest_bag/manifest-md5.txt
+++ b/tests/test_delete_thumbs_db/not_manifest_bag/manifest-md5.txt
@@ -1,0 +1,2 @@
+d98653c4abcca7e5156e92db5e5bde51  data/Document.txt
+d98653c4abcca7e5156e92db5e5bde51  data/Folder/Document.txt

--- a/tests/test_delete_thumbs_db/not_manifest_bag/tagmanifest-md5.txt
+++ b/tests/test_delete_thumbs_db/not_manifest_bag/tagmanifest-md5.txt
@@ -1,0 +1,3 @@
+ca15cd633c3b70397f79717f176a87cd bag-info.txt
+9e5ad981e0d29adc278f6a294b8c2aca bagit.txt
+80e487d3456dd154a24e14331000b85f manifest-md5.txt


### PR DESCRIPTION
Delete all Thumbs.db in the bag, whether or not they are in the manifest, update the bag, and validate the bag. This is for correcting a common error found when re-validating bagged accessions in the backlog.

This is similar to delete_new_temp.py, which deletes any temporary files (not just Thumbs.db) but only if they are not in the manifest.