### PR TITLE
Issue#53 logging undo bags

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Thumbs.db are the only reason the bag is not validating, because it updates the 
 
 ### undo_bags.py
 
-Purpose: remove files from each bag in bag_directory if it is valid. It does work if there is a single bag.
+Purpose: remove files from each bag in bag_directory if it is valid and log the results. 
+It does work if there is a single bag.
 
 Argument: bag_directory (required): path to directory that contains the bag or bags. 
 Bag folder names should end with "_bag".

--- a/tests/test_undo_bags.py
+++ b/tests/test_undo_bags.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import subprocess
 import unittest
-from test_functions import make_directory_list
+from test_functions import csv_to_list, make_directory_list
 
 
 class MyTestCase(unittest.TestCase):
@@ -25,7 +25,7 @@ class MyTestCase(unittest.TestCase):
         bag_dir = os.path.join(os.getcwd(), 'test_undo_bags', 'bag_dir')
         subprocess.run(f'python {script_path} {bag_dir}', shell=True)
 
-        # Tests that the contents of the folders are correct.
+        # Tests that the contents of the directory are correct.
         result = make_directory_list(bag_dir)
         expected = [os.path.join(bag_dir, 'aip_1'),
                     os.path.join(bag_dir, 'aip_1', 'Test File.txt'),
@@ -41,7 +41,14 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(bag_dir, 'folder', 'keep_bag', 'data', 'Test File.txt'),
                     os.path.join(bag_dir, 'folder', 'keep_bag', 'manifest-md5.txt'),
                     os.path.join(bag_dir, 'folder', 'keep_bag', 'tagmanifest-md5.txt')]
-        self.assertEqual(expected, result, "Problem with test for hierarchy")
+        self.assertEqual(expected, result, "Problem with test for hierarchy, directory")
+        
+        # Tests the log contents are correct.
+        result = csv_to_list(os.path.join(bag_dir, 'bag_undo_log.csv'))
+        expected = [['Bag_Path', 'Bag_Valid', 'Errors'],
+                    [os.path.join(bag_dir, 'aip_1_bag'), 'True', 'BLANK'],
+                    [os.path.join(bag_dir, 'aip_2_bag'), 'True', 'BLANK']]
+        self.assertEqual(expected, result, "Problem with test for hierarchy, log")
 
     def test_one(self):
         """Test for when there is one bag in bag_dir"""
@@ -55,12 +62,18 @@ class MyTestCase(unittest.TestCase):
         bag_dir = os.path.join(os.getcwd(), 'test_undo_bags', 'bag_dir')
         subprocess.run(f'python {script_path} {bag_dir}', shell=True)
 
-        # Tests that the contents of the folders are correct.
+        # Tests that the contents of the directory are correct.
         result = make_directory_list(bag_dir)
         expected = [os.path.join(bag_dir, 'aip_1'),
                     os.path.join(bag_dir, 'aip_1', 'Test File.txt'),
                     os.path.join(bag_dir, 'bag_undo_log.csv')]
-        self.assertEqual(expected, result, "Problem with test for one")
+        self.assertEqual(expected, result, "Problem with test for one, directory")
+
+        # Tests the log contents are correct.
+        result = csv_to_list(os.path.join(bag_dir, 'bag_undo_log.csv'))
+        expected = [['Bag_Path', 'Bag_Valid', 'Errors'],
+                    [os.path.join(bag_dir, 'aip_1_bag'), 'True', 'BLANK']]
+        self.assertEqual(expected, result, "Problem with test for one, log")
 
     def test_two(self):
         """Test for when there are two bags in bag_dir"""
@@ -74,7 +87,7 @@ class MyTestCase(unittest.TestCase):
         bag_dir = os.path.join(os.getcwd(), 'test_undo_bags', 'bag_dir')
         subprocess.run(f'python {script_path} {bag_dir}', shell=True)
 
-        # Tests that the contents of the folders are correct.
+        # Tests that the contents of the directory are correct.
         result = make_directory_list(bag_dir)
         expected = [os.path.join(bag_dir, 'aip_1'),
                     os.path.join(bag_dir, 'aip_1', 'Test File.txt'),
@@ -82,7 +95,14 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(bag_dir, 'aip_2', 'File_One.txt'),
                     os.path.join(bag_dir, 'aip_2', 'File_Two.txt'),
                     os.path.join(bag_dir, 'bag_undo_log.csv')]
-        self.assertEqual(expected, result, "Problem with test for two")
+        self.assertEqual(expected, result, "Problem with test for two, directory")
+
+        # Tests the log contents are correct.
+        result = csv_to_list(os.path.join(bag_dir, 'bag_undo_log.csv'))
+        expected = [['Bag_Path', 'Bag_Valid', 'Errors'],
+                    [os.path.join(bag_dir, 'aip_1_bag'), 'True', 'BLANK'],
+                    [os.path.join(bag_dir, 'aip_2_bag'), 'True', 'BLANK']]
+        self.assertEqual(expected, result, "Problem with test for two, log")
 
     def test_unexpected_error(self):
         """Test for when a bag has other files and a folder mixed with the bag metadata files"""
@@ -96,7 +116,7 @@ class MyTestCase(unittest.TestCase):
         bag_dir = os.path.join(os.getcwd(), 'test_undo_bags', 'bag_dir')
         subprocess.run(f'python {script_path} {bag_dir}', shell=True)
 
-        # Tests that the contents of the folders are correct.
+        # Tests that the contents of the directory are correct.
         result = make_directory_list(bag_dir)
         expected = [os.path.join(bag_dir, 'aip_1_bag'),
                     os.path.join(bag_dir, 'aip_1_bag', 'a_extra_file.txt'),
@@ -106,7 +126,16 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(bag_dir, 'aip_1_bag', 'data', 'Test File.txt'),
                     os.path.join(bag_dir, 'aip_1_bag', 'extra_file2.txt'),
                     os.path.join(bag_dir, 'bag_undo_log.csv')]
-        self.assertEqual(expected, result, "Problem with test for unexpected_error")
+        self.assertEqual(expected, result, "Problem with test for unexpected_error, directory")
+
+        # Tests the log contents are correct.
+        result = csv_to_list(os.path.join(bag_dir, 'bag_undo_log.csv'))
+        expected = [['Bag_Path', 'Bag_Valid', 'Errors'],
+                    [os.path.join(bag_dir, 'aip_1_bag'), 'True',
+                     f"Unexpected content mixed with bag metadata: {os.path.join(bag_dir, 'aip_1_bag', 'aip_1_FITS')}, "
+                     f"{os.path.join(bag_dir, 'aip_1_bag', 'a_extra_file.txt')}, "
+                     f"{os.path.join(bag_dir, 'aip_1_bag', 'extra_file2.txt')}"]]
+        self.assertEqual(expected, result, "Problem with test for unexpected_error, log")
 
     def test_validation_error(self):
         """Test for when there are two bags in bag_dir and one is not valid (is not undone)"""
@@ -120,7 +149,7 @@ class MyTestCase(unittest.TestCase):
         bag_dir = os.path.join(os.getcwd(), 'test_undo_bags', 'bag_dir')
         subprocess.run(f'python {script_path} {bag_dir}', shell=True)
 
-        # Tests that the contents of the folders are correct.
+        # Tests that the contents of the directory are correct.
         result = make_directory_list(bag_dir)
         expected = [os.path.join(bag_dir, 'bag_undo_log.csv'),
                     os.path.join(bag_dir, 'not_valid_bag'),
@@ -133,7 +162,15 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(bag_dir, 'valid'),
                     os.path.join(bag_dir, 'valid', 'File_One.txt'),
                     os.path.join(bag_dir, 'valid', 'File_Two.txt')]
-        self.assertEqual(expected, result, "Problem with test for validation_error")
+        self.assertEqual(expected, result, "Problem with test for validation_error, directory")
+
+        # Tests the log contents are correct.
+        result = csv_to_list(os.path.join(bag_dir, 'bag_undo_log.csv'))
+        expected = [['Bag_Path', 'Bag_Valid', 'Errors'],
+                    [os.path.join(bag_dir, 'not_valid_bag'), 'False',
+                     'Payload-Oxum validation failed. Expected 1 files and 19 bytes but found 1 files and 40 bytes'],
+                    [os.path.join(bag_dir, 'valid_bag'), 'True', 'BLANK']]
+        self.assertEqual(expected, result, "Problem with test for validation_error, log")
 
 
 if __name__ == '__main__':

--- a/tests/test_undo_bags.py
+++ b/tests/test_undo_bags.py
@@ -32,6 +32,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(bag_dir, 'aip_2'),
                     os.path.join(bag_dir, 'aip_2', 'File_One.txt'),
                     os.path.join(bag_dir, 'aip_2', 'File_Two.txt'),
+                    os.path.join(bag_dir, 'bag_undo_log.csv'),
                     os.path.join(bag_dir, 'folder'),
                     os.path.join(bag_dir, 'folder', 'keep_bag'),
                     os.path.join(bag_dir, 'folder', 'keep_bag', 'bag-info.txt'),
@@ -57,7 +58,8 @@ class MyTestCase(unittest.TestCase):
         # Tests that the contents of the folders are correct.
         result = make_directory_list(bag_dir)
         expected = [os.path.join(bag_dir, 'aip_1'),
-                    os.path.join(bag_dir, 'aip_1', 'Test File.txt')]
+                    os.path.join(bag_dir, 'aip_1', 'Test File.txt'),
+                    os.path.join(bag_dir, 'bag_undo_log.csv')]
         self.assertEqual(expected, result, "Problem with test for one")
 
     def test_two(self):
@@ -78,7 +80,8 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(bag_dir, 'aip_1', 'Test File.txt'),
                     os.path.join(bag_dir, 'aip_2'),
                     os.path.join(bag_dir, 'aip_2', 'File_One.txt'),
-                    os.path.join(bag_dir, 'aip_2', 'File_Two.txt')]
+                    os.path.join(bag_dir, 'aip_2', 'File_Two.txt'),
+                    os.path.join(bag_dir, 'bag_undo_log.csv')]
         self.assertEqual(expected, result, "Problem with test for two")
 
     def test_unexpected_error(self):
@@ -101,7 +104,8 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(bag_dir, 'aip_1_bag', 'aip_1_FITS', 'FITS Placeholder.txt'),
                     os.path.join(bag_dir, 'aip_1_bag', 'data'),
                     os.path.join(bag_dir, 'aip_1_bag', 'data', 'Test File.txt'),
-                    os.path.join(bag_dir, 'aip_1_bag', 'extra_file2.txt'), ]
+                    os.path.join(bag_dir, 'aip_1_bag', 'extra_file2.txt'),
+                    os.path.join(bag_dir, 'bag_undo_log.csv')]
         self.assertEqual(expected, result, "Problem with test for unexpected_error")
 
     def test_validation_error(self):
@@ -118,7 +122,8 @@ class MyTestCase(unittest.TestCase):
 
         # Tests that the contents of the folders are correct.
         result = make_directory_list(bag_dir)
-        expected = [os.path.join(bag_dir, 'not_valid_bag'),
+        expected = [os.path.join(bag_dir, 'bag_undo_log.csv'),
+                    os.path.join(bag_dir, 'not_valid_bag'),
                     os.path.join(bag_dir, 'not_valid_bag', 'bag-info.txt'),
                     os.path.join(bag_dir, 'not_valid_bag', 'bagit.txt'),
                     os.path.join(bag_dir, 'not_valid_bag', 'data'),

--- a/tests/test_undo_bags/unexpected_error_copy/aip_1_bag/tagmanifest-md5.txt
+++ b/tests/test_undo_bags/unexpected_error_copy/aip_1_bag/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-8e2b89e8c3e1e047bdc694f15f1085ed bag-info.txt
+8a23b4793e9b4b4aadde90f73eeefb2d bag-info.txt
 defc71b28593bb73c7c94a8332f85da8 bagit.txt
-a48677e8348b9b63a14ececf9943bd94 manifest-md5.txt
+dbfc82ebc98bf587ceade283fc42dcb6 manifest-md5.txt

--- a/undo_bags.py
+++ b/undo_bags.py
@@ -17,7 +17,7 @@ Returns:
 """
 import os
 import sys
-from shared_functions import validate_bag
+from shared_functions import log, validate_bag
 
 
 def delete_metadata(bag):
@@ -83,7 +83,16 @@ def rename(bag):
 
 
 if __name__ == '__main__':
+
+    # Parent folder of the bag(s) to be undone.
     bag_dir = sys.argv[1]
+
+    # Starts the bag validation log in the same folder as the bags.
+    log_file = log_path = os.path.join(bag_dir, 'bag_validation_log.csv')
+    log(log_file, ['Bag_Path', 'Bag_Valid', 'Errors'])
+
+    # Finds all bags directly within the bag directory, based on the folder naming convention,
+    # undoes the bag (stopping if there is an error) and logs the result.
     for folder in os.listdir(bag_dir):
         if folder.endswith('_bag'):
             bag_path = os.path.join(bag_dir, folder)

--- a/undo_bags.py
+++ b/undo_bags.py
@@ -12,6 +12,7 @@ Parameter:
     bag_directory (required): path to the directory with the bag or bags
 
 Returns:
+    bag_undo_log.csv (in bag_directory)
     All folders originally within bags directly within the bag_directory will no longer be in bags:
     no bag manifests, no data folder, and "_bag" ending removed from the folder.
 """

--- a/undo_bags.py
+++ b/undo_bags.py
@@ -109,6 +109,7 @@ if __name__ == '__main__':
                     correct_reorg = reorganize(bag_path)
                     if correct_reorg:
                         rename(bag_path)
+                        log(log_path, [bag_path, True, None])
                     else:
                         log(log_path, [bag_path, True, 'data folder not empty after reorganize'])
             else:

--- a/undo_bags.py
+++ b/undo_bags.py
@@ -103,13 +103,13 @@ if __name__ == '__main__':
                 # Only continue with reorganizing the bag if there are no unexpected files mixed with bag metadata.
                 unexpected = delete_metadata(bag_path)
                 if unexpected:
-                    print(unexpected)
+                    log(log_path, [bag_path, True, unexpected])
                 else:
                     # Only continue with renaming the bag if the data folder was empty and could be deleted.
                     correct_reorg = reorganize(bag_path)
                     if correct_reorg:
                         rename(bag_path)
                     else:
-                        print("Error: data folder not empty after reorganize")
+                        log(log_path, [bag_path, True, 'data folder not empty after reorganize'])
             else:
-                print("Bag is not valid. Review before undoing.")
+                log(log_path, [bag_path, False, errors])

--- a/undo_bags.py
+++ b/undo_bags.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
     bag_dir = sys.argv[1]
 
     # Starts the bag validation log in the same folder as the bags.
-    log_file = log_path = os.path.join(bag_dir, 'bag_validation_log.csv')
+    log_file = log_path = os.path.join(bag_dir, 'bag_undo_log.csv')
     log(log_file, ['Bag_Path', 'Bag_Valid', 'Errors'])
 
     # Finds all bags directly within the bag directory, based on the folder naming convention,

--- a/undo_bags.py
+++ b/undo_bags.py
@@ -49,7 +49,7 @@ def delete_metadata(bag):
     if len(unexpected_list) == 0:
         return None
     else:
-        return f"Unexpected files mixed with bag metadata: {', '.join(unexpected_list)}"
+        return f"Unexpected content mixed with bag metadata: {', '.join(unexpected_list)}"
 
 
 def reorganize(bag):


### PR DESCRIPTION
Make log named bag_undo_log.csv in the bag directory with each bag's path, if it was valid prior to unbagging, and if there are any errors. It is faster to review than looking at what is printed in the terminal and keeps the information from being lost if the computer restarts or the terminal is otherwise closed after the script is done.