### PR TITLE
Issue#44 output as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ since bagit does not indicate which files were added or deleted since the bag wa
 Purpose: compare the MD5s in the bag manifest to the MD5s of files in the bag data folder and make a report of the differences, 
 either because the fixity changed or the file is only in one location.
 
-Argument: bag_path (required): path to the bag (folder that ends in "_bag")
+Arguments: 
+* bag_path (required): path to the bag (folder that ends in "_bag")
+* output_path (required): path to folder for output, use local machine if saving to Hub gives PermissionError
 
 This script was developed for investigating a bag validation error from the size changing,
 since bagit does not indicate which files changed in size since the bag was made.

--- a/compare_fixity.py
+++ b/compare_fixity.py
@@ -11,6 +11,7 @@ This script is modeled after the function validate_bag_manifest() in validate_fi
 
 Parameters:
     bag_path (required): path to the bag folder
+    output_path (required): path to folder for output, use local machine if saving to Hub gives PermissionError
 
 Returns:
     compare_fixity_report.csv (saved to the parent folder of the bag_path)

--- a/compare_fixity.py
+++ b/compare_fixity.py
@@ -144,7 +144,7 @@ def save_report(df_diff, output):
 if __name__ == '__main__':
 
     bag_path = sys.argv[1]
-    output_path = os.path.dirname(bag_path)
+    output_path = sys.argv[2]
 
     make_data_md5_csv(bag_path, output_path)
     manifest_df = make_manifest_df(bag_path)

--- a/tests/test_compare_fixity.py
+++ b/tests/test_compare_fixity.py
@@ -12,16 +12,9 @@ class MyTestCase(unittest.TestCase):
 
     def tearDown(self):
         """Deletes the manifest compare report and data_md5.csv, if it was made"""
-        # For most tests, the files are in the same location, with the same name.
         filenames = ['compare_fixity_report.csv', 'data_md5.csv']
         for filename in filenames:
             file_path = os.path.join(os.getcwd(), 'test_compare_fixity', filename)
-            if os.path.exists(file_path):
-                os.remove(file_path)
-
-        # For the restart test, the files have the same names but are in a different location.
-        for filename in filenames:
-            file_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'restart_dir', filename)
             if os.path.exists(file_path):
                 os.remove(file_path)
 
@@ -31,10 +24,11 @@ class MyTestCase(unittest.TestCase):
         # Makes variables needed and runs the script.
         script_path = os.path.join('..', 'compare_fixity.py')
         bag_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'added_bag')
-        subprocess.run(f'python {script_path} {bag_path}')
+        output_path = os.path.join(os.getcwd(), 'test_compare_fixity')
+        subprocess.run(f'python {script_path} {bag_path} {output_path}')
 
         # Tests the manifest compare report has the correct information.
-        report_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'compare_fixity_report.csv')
+        report_path = os.path.join(output_path, 'compare_fixity_report.csv')
         result = csv_to_list(report_path)
         expected = [['MD5', 'Path', 'Source'],
                     ['89c60670864545fbc6b508503ef67ccb', 'data/File_1a.txt', 'Data Folder'],
@@ -43,7 +37,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for added, compare report")
 
         # Tests the data_md5.csv has the correction information.
-        report_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'data_md5.csv')
+        report_path = os.path.join(output_path, 'data_md5.csv')
         result = csv_to_list(report_path)
         expected = [['a31ad967b49226c29700a71e20e91ad6', 'data/File_1.txt'],
                     ['89c60670864545fbc6b508503ef67ccb', 'data/File_1a.txt'],
@@ -58,17 +52,18 @@ class MyTestCase(unittest.TestCase):
         # Makes variables needed and runs the script.
         script_path = os.path.join('..', 'compare_fixity.py')
         bag_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'deleted_bag')
-        subprocess.run(f'python {script_path} {bag_path}')
+        output_path = os.path.join(os.getcwd(), 'test_compare_fixity')
+        subprocess.run(f'python {script_path} {bag_path} {output_path}')
 
         # Tests the manifest compare report has the correct information.
-        report_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'compare_fixity_report.csv')
+        report_path = os.path.join(output_path, 'compare_fixity_report.csv')
         result = csv_to_list(report_path)
         expected = [['MD5', 'Path', 'Source'],
                     ['893c9bca3cf9d6c9af9828f06c3eeb78', 'data/File_1.txt', 'Manifest']]
         self.assertEqual(expected, result, "Problem with test for deleted, compare report")
 
         # Tests the data_md5.csv has the correction information.
-        report_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'data_md5.csv')
+        report_path = os.path.join(output_path, 'data_md5.csv')
         result = csv_to_list(report_path)
         expected = [['2486ea837419dc36af7f6dd9e2e0f96c', 'data/File_2.txt']]
         self.assertEqual(expected, result, "Problem with test for deleted, data md5")
@@ -79,10 +74,11 @@ class MyTestCase(unittest.TestCase):
         # Makes variables needed and runs the script.
         script_path = os.path.join('..', 'compare_fixity.py')
         bag_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'edited_bag')
-        subprocess.run(f'python {script_path} {bag_path}')
+        output_path = os.path.join(os.getcwd(), 'test_compare_fixity')
+        subprocess.run(f'python {script_path} {bag_path} {output_path}')
 
         # Tests the manifest compare report has the correct information.
-        report_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'compare_fixity_report.csv')
+        report_path = os.path.join(output_path, 'compare_fixity_report.csv')
         result = csv_to_list(report_path)
         expected = [['MD5', 'Path', 'Source'],
                     ['a31ad967b49226c29700a71e20e91ad6', 'data/File_1.txt', 'Data Folder'],
@@ -92,7 +88,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for edited, compare report")
 
         # Tests the data_md5.csv has the correction information.
-        report_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'data_md5.csv')
+        report_path = os.path.join(output_path, 'data_md5.csv')
         result = csv_to_list(report_path)
         expected = [['a31ad967b49226c29700a71e20e91ad6', 'data/File_1.txt'],
                     ['dbed2c145ec5a3ef5877753abefdabf6', 'data/File_2.txt'],
@@ -105,13 +101,13 @@ class MyTestCase(unittest.TestCase):
         # Makes variables needed and runs the script.
         script_path = os.path.join('..', 'compare_fixity.py')
         bag_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'restart_dir', 'restart_bag')
+        output_path = os.path.join(os.getcwd(), 'test_compare_fixity')
         shutil.copy(os.path.join(os.getcwd(), 'test_compare_fixity', 'restart_dir', 'data_md5_copy.csv'),
-                    os.path.join(os.getcwd(), 'test_compare_fixity', 'restart_dir', 'data_md5.csv'))
-        subprocess.run(f'python {script_path} {bag_path}')
+                    os.path.join(output_path, 'data_md5.csv'))
+        subprocess.run(f'python {script_path} {bag_path} {output_path}')
 
         # Tests the manifest compare report has the correct information.
-        report_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'restart_dir',
-                                   'compare_fixity_report.csv')
+        report_path = os.path.join(output_path, 'compare_fixity_report.csv')
         result = csv_to_list(report_path)
         expected = [['MD5', 'Path', 'Source'],
                     ['0000x668xx2218xx2b23x576347x9386', 'data/Folder/File_2.txt', 'Data Folder'],
@@ -121,7 +117,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(expected, result, "Problem with test for restart, compare report")
 
         # Tests the data_md5.csv has the correction information.
-        report_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'restart_dir', 'data_md5.csv')
+        report_path = os.path.join(output_path, 'data_md5.csv')
         result = csv_to_list(report_path)
         expected = [['a31ad967b49226c29700a71e20e91ad6', 'data/File_1.txt'],
                     ['0000x668xx2218xx2b23x576347x9386', 'data/Folder/File_2.txt'],
@@ -136,16 +132,17 @@ class MyTestCase(unittest.TestCase):
         # Makes variables needed and runs the script.
         script_path = os.path.join('..', 'compare_fixity.py')
         bag_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'valid_bag')
-        subprocess.run(f'python {script_path} {bag_path}')
+        output_path = os.path.join(os.getcwd(), 'test_compare_fixity')
+        subprocess.run(f'python {script_path} {bag_path} {output_path}')
 
         # Tests the manifest compare report has the correct information.
-        report_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'compare_fixity_report.csv')
+        report_path = os.path.join(output_path, 'compare_fixity_report.csv')
         result = csv_to_list(report_path)
         expected = [['The bag is valid. No differences between the manifest and the data folder contents.']]
         self.assertEqual(expected, result, "Problem with test for valid, compare report")
 
         # Tests the data_md5.csv has the correction information.
-        report_path = os.path.join(os.getcwd(), 'test_compare_fixity', 'data_md5.csv')
+        report_path = os.path.join(output_path, 'data_md5.csv')
         result = csv_to_list(report_path)
         expected = [['a31ad967b49226c29700a71e20e91ad6', 'data/File_1.txt'],
                     ['89c60670864545fbc6b508503ef67ccb', 'data/File_1a.txt'],


### PR DESCRIPTION
Add a second argument, output_path, for where the script compare_fixity.py should save data_md5.csv and the comparison report. 

This was always the parent of the bag directory (first path), but that sometimes results in a PermissionError when the bag is in our Hub storage. This doesn't happen if output_path is on a local machine and it can complete successfully even when the bag is in Hub.